### PR TITLE
support multiple languages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ import os
 
 import click
 
+from devtale.constants import ALLOWED_EXTENSIONS, LANGUAGES
 from devtale.utils import (
     fuse_tales,
     get_tale_index,
@@ -15,7 +16,7 @@ from devtale.utils import (
 
 DEFAULT_OUTPUT_PATH = "devtale_demo/"
 DEFAULT_MODEL_NAME = "gpt-3.5-turbo"
-ALLOWED_EXTENSIONS = [".php"]
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -102,11 +103,14 @@ def document_file(
 
     logger.info("read dev draft")
     file_name = os.path.basename(file_path)
+    file_ext = os.path.splitext(file_name)[-1]
+    logger.info(f"extension: {file_ext}")
+
     with open(file_path, "r") as file:
         code = file.read()
 
     logger.info("split dev draft ideas")
-    docs = split(code, chunk_size=3000)
+    docs = split(code, language=LANGUAGES[file_ext], chunk_size=3000)
 
     logger.info("create tale sections")
     tales_list = []

--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -1,0 +1,22 @@
+from langchain.text_splitter import Language
+
+# we are only documenting the file that ends with the following extensions:
+ALLOWED_EXTENSIONS = [".php", ".py"]
+
+# split code files according the programming language
+LANGUAGES = {
+    ".php": Language.PHP,
+    ".py": Language.PYTHON,
+    ".cpp": Language.CPP,
+    ".java": Language.JAVA,
+    ".js": Language.JS,
+}
+
+# indeitifers used to add documentation into the files.
+IDENTIFIERS = {
+    "php": [["class"], ["function"]],
+    "python": [["class"], ["def"]],
+    "cpp": [["class"], ["void", "int", "float", "double"]],
+    "java": [["class"], ["public", "protected", "private", "static"]],
+    "js": [["class"], ["function", "const", "let", "var"]],
+}

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -1,10 +1,9 @@
 import json
-import re
 
 from langchain import LLMChain, PromptTemplate
 from langchain.chat_models import ChatOpenAI
 from langchain.output_parsers import PydanticOutputParser
-from langchain.text_splitter import Language, RecursiveCharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from devtale.schema import FileDocumentation
 from devtale.templates import (
@@ -13,10 +12,8 @@ from devtale.templates import (
     FOLDER_LEVEL_TEMPLATE,
 )
 
-identifiers = {"php": ["class", "function"]}
 
-
-def split(code, language=Language.PHP, chunk_size=1000, chunk_overlap=0):
+def split(code, language, chunk_size=1000, chunk_overlap=0):
     code_splitter = RecursiveCharacterTextSplitter.from_language(
         language=language, chunk_size=chunk_size, chunk_overlap=0
     )
@@ -63,35 +60,6 @@ def get_unit_tale(doc, model_name="gpt-3.5-turbo", verbose=False):
         empty = {"classes": [], "methods": []}
         return empty
     return result_json
-
-
-def add_tales(docstrings, code, language="php", signature="@AI-generated docstring"):
-    documented_code = code
-    class_identifier = identifiers[language][0]
-    method_identifier = identifiers[language][1]
-
-    # write class-level docstrings
-    for class_info in docstrings["classes"]:
-        class_name = class_info["class_name"]
-        class_docstring = class_info["class_docstring"]
-        documented_code = re.sub(
-            r"(" + class_identifier + "\s+" + re.escape(class_name) + r"\s*\{)",
-            r"/** " + signature + "\n * " + class_docstring + r"\n */\n\1",
-            documented_code,
-            count=1,
-        )
-
-    # write method-level docstrings
-    for method_info in docstrings["methods"]:
-        method_name = method_info["method_name"]
-        method_docstring = method_info["method_docstring"]
-        documented_code = re.sub(
-            r"(" + method_identifier + "\s+" + re.escape(method_name) + r"\s*\()",
-            r"\n/** " + signature + "\n * " + method_docstring + r"\n */\n\1",
-            documented_code,
-        )
-
-    return documented_code
 
 
 def fuse_tales(tales_list):


### PR DESCRIPTION
closes #8 

This allows to create docstring for  multiple languages knowing that we are returning only a JSON with the docstrings. If we want to add the docstrings in the code files, we will need to extend this support according to each language. 