### PR TITLE
Add escape characters to handle multiline GPT outputs 

### DIFF
--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -29,10 +29,12 @@ code elements.
 2. For each identified code element, generate a Google Style docstring.
 
 Focus only on the code elements that are present and defined within the code snippet.
+And please refrain from including docstrings within the code.
 
 {format_instructions}
 
-Do not introduce your answer, just output using the above JSON schema.
+Do not introduce your answer, just output using the above JSON schema, and always \
+use escaped newlines.
 
 Input: <<< {code} >>>
 """

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -114,12 +114,10 @@ def get_unit_tale(short_doc, code_elements, model_name="gpt-4", verbose=False):
 
             if start_index != -1 and end_index != -1 and start_index < end_index:
                 json_text = text[start_index : end_index + 1]
-                result_json = json.loads(json_text)
-            else:
-                print(f"Ivalid JSON {text}")
-                print("Returning empty JSON instead")
-                empty = {"classes": [], "methods": []}
-                return empty
+
+            json_text = _add_escape_characters(json_text)
+            result_json = json.loads(json_text)
+
         except Exception as e:
             print(
                 f"Error getting the JSON with the docstrings. \
@@ -167,3 +165,14 @@ def fuse_tales(tales_list, code, code_elements_dict):
                     fused_tale["methods"].append(method)
 
     return fused_tale
+
+
+def _add_escape_characters(invalid_json):
+    control_char_pattern = re.compile(r"[\x00-\x1F\x7F-\x9F]")
+    unescaped_chars = control_char_pattern.findall(invalid_json)
+
+    # Escape the unescaped control characters
+    for char in unescaped_chars:
+        json_string = invalid_json.replace(char, "\\u{:04x}".format(ord(char)))
+
+    return json_string


### PR DESCRIPTION
Fixes #17 

GPT occasionally returns docstring text without escape characters, which can lead to crashes when attempting to convert the output into JSON. This pull request introduces a method to rectify the output and enable proper JSON loading