### PR TITLE
Use gitignore to filter folders and files

### DIFF
--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -1,7 +1,7 @@
 from langchain.text_splitter import Language
 
 # we are only documenting the file that ends with the following extensions:
-ALLOWED_EXTENSIONS = [".php", ".py"]
+ALLOWED_EXTENSIONS = [".php", ".py", ""]
 
 # split code files according the programming language
 LANGUAGES = {

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -39,6 +39,15 @@ use escaped newlines.
 Input: <<< {code} >>>
 """
 
+UNKNOWN_FILE_LEVEL_TEMPLATE = """
+Using the following code enclosed within the <<< >>> delimeters write a top-file level \
+docstring for a concise summary that effectively captures the overall purpose and \
+functionality of the code.
+
+code: <<< {information} >>>
+
+Ensure your final summary is no longer than three sentences.
+"""
 
 FILE_LEVEL_TEMPLATE = """
 The following summaries enclosed within the <<< >>> delimeters are derived from the \


### PR DESCRIPTION
This PR extends the usage of gitignore to be used as filter. It also adds logic to process files without extensions assuming they are bash files