### PR TITLE
Fix regression caused by modifying the main README format

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -75,7 +75,6 @@ def process_repository(
     folders_readmes = []
     for folder_path in folders:
         try:
-            # if folder_path == root_path:
             if not folder_path.endswith("/"):
                 folder_path += "/"
 

--- a/cli.py
+++ b/cli.py
@@ -80,9 +80,18 @@ def process_repository(
                 folder_path += "/"
 
             folder_full_name = os.path.relpath(folder_path, root_path)
+
             folder_readme, folder_tale = process_folder(
-                folder_path, output_path, model_name, fuse, debug, folder_full_name
+                folder_path=folder_path,
+                output_path=os.path.join(output_path, folder_full_name)
+                if folder_full_name != "."
+                else output_path,
+                model_name=model_name,
+                fuse=fuse,
+                debug=debug,
+                folder_full_name=folder_full_name,
             )
+
         except Exception as e:
             folder_name = os.path.basename(folder_path)
             logger.info(
@@ -211,10 +220,11 @@ def process_folder(
 
     if debug:
         logger.debug(
-            f"""
-                FOLDER INFO:\nfolder_path: {folder_path}\n
-                output_path: {output_path}\n
-                save_path: {save_path}"""
+            f"""FOLDER INFO:
+        folder_path: {folder_path}
+        output_path: {output_path}
+        save_path: {save_path}
+        """
         )
         logger.debug(f"FILE_TALES: {tales}")
         return "", ""

--- a/cli.py
+++ b/cli.py
@@ -24,7 +24,7 @@ DEFAULT_OUTPUT_PATH = "devtale_demo/"
 DEFAULT_MODEL_NAME = "gpt-4"
 
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -281,8 +281,11 @@ def process_file(
         return found_tale
 
     if not file_ext:
-        bash_docstring = redact_tale_information("unknow-top-level", code)["text"]
-        return {"file_docstring": bash_docstring}
+        unknown_file_data = {"file_name": file_name, "file_content": code}
+        file_docstring = redact_tale_information("unknow-top-level", unknown_file_data)[
+            "text"
+        ]
+        return {"file_docstring": file_docstring}
 
     logger.info("split dev draft ideas")
     big_docs = split_code(code, language=LANGUAGES[file_ext], chunk_size=10000)

--- a/cli.py
+++ b/cli.py
@@ -234,7 +234,7 @@ def process_folder(
         folder_readme = folder_readme.replace("----------", "")
 
         folder_overview = redact_tale_information(
-            "folder-description", folder_readme, model_name="text-davinci-003"
+            "folder-description", folder_readme, model_name="gpt-3.5-turbo-16k"
         )["text"]
 
         logger.info("save folder json..")

--- a/cli.py
+++ b/cli.py
@@ -38,7 +38,6 @@ def process_repository(
         "repository_name": os.path.basename(os.path.abspath(root_path)),
         "folders": [],
     }
-
     # get project structure before we modify it
     gitignore_path = os.path.join(root_path, ".gitignore")
     if os.path.exists(gitignore_path):
@@ -55,11 +54,13 @@ def process_repository(
     project_tree = ".\n" + project_tree
 
     folders = list(set([os.path.dirname(file_path) for file_path in file_paths]))
-    folders_readmes = []
+    folders = sorted(folders, key=lambda path: path.count("/"))
 
+    folders_readmes = []
     for folder_path in folders:
         try:
-            if folder_path == root_path:
+            # if folder_path == root_path:
+            if not folder_path.endswith("/"):
                 folder_path += "/"
 
             folder_full_name = os.path.relpath(folder_path, root_path)
@@ -74,6 +75,7 @@ def process_repository(
             folder_tale = None
 
         if folder_tale is not None:
+            folders_readmes.append("\n\n" + folder_readme)
             # add root folder summary information
             if (
                 os.path.basename(folder_path) == os.path.basename(root_path + "/")
@@ -87,7 +89,6 @@ def process_repository(
                     }
                 )
             else:
-                folders_readmes.append("\n" + folder_readme)
                 folder_tales["folders"].append(
                     {
                         "folder_name": os.path.basename(folder_path),
@@ -104,7 +105,7 @@ def process_repository(
 
         # inject folders information
         if folders_readmes:
-            folders_information = "\n\n## Folders\n" + "".join(folders_readmes)
+            folders_information = "\n\n## Folders" + "".join(folders_readmes)
             root_readme = root_readme + folders_information
 
         # inject project tree

--- a/cli.py
+++ b/cli.py
@@ -192,6 +192,10 @@ def process_folder(
                         folder_full_name = os.path.basename(
                             os.path.abspath(folder_path)
                         )
+
+                    if folder_full_name == ".":
+                        folder_full_name = "./"
+
                     folder_entry = next(
                         (
                             item
@@ -205,6 +209,14 @@ def process_folder(
                             "folder_name": folder_full_name,
                             "folder_files": [],
                         }
+                        if folder_full_name == ".":
+                            folder_entry[
+                                "folder_description"
+                            ] = """
+                            This is the root path of the repository. The top-level
+                            directory.
+                            """
+
                         tales.append(folder_entry)
 
                     folder_entry["folder_files"].append(

--- a/cli.py
+++ b/cli.py
@@ -61,8 +61,10 @@ def process_repository(
         try:
             if folder_path == root_path:
                 folder_path += "/"
+
+            folder_full_name = os.path.relpath(folder_path, root_path)
             folder_readme, folder_tale = process_folder(
-                folder_path, output_path, model_name, fuse
+                folder_path, output_path, model_name, fuse, folder_full_name
             )
         except Exception as e:
             folder_name = os.path.basename(folder_path)
@@ -125,6 +127,7 @@ def process_folder(
     output_path: str = DEFAULT_OUTPUT_PATH,
     model_name: str = DEFAULT_MODEL_NAME,
     fuse: bool = False,
+    folder_full_name: str = None,
 ) -> None:
     save_path = os.path.join(output_path, os.path.basename(folder_path))
     tales = []
@@ -147,14 +150,21 @@ def process_folder(
 
             if file_tale is not None:
                 if file_tale["file_docstring"]:
-                    folder_name = os.path.basename(os.path.abspath(folder_path))
+                    if not folder_full_name:
+                        folder_full_name = os.path.basename(
+                            os.path.abspath(folder_path)
+                        )
                     folder_entry = next(
-                        (item for item in tales if item["folder_name"] == folder_name),
+                        (
+                            item
+                            for item in tales
+                            if item["folder_name"] == folder_full_name
+                        ),
                         None,
                     )
                     if folder_entry is None:
                         folder_entry = {
-                            "folder_name": folder_name,
+                            "folder_name": folder_full_name,
                             "folder_files": [],
                         }
                         tales.append(folder_entry)

--- a/cli.py
+++ b/cli.py
@@ -99,13 +99,10 @@ def process_repository(
             )
             folder_tale = None
 
-        if folder_tale is not None:
+        if folder_tale:
             folders_readmes.append("\n\n" + folder_readme)
             # add root folder summary information
-            if (
-                os.path.basename(folder_path) == os.path.basename(root_path + "/")
-                or os.path.basename(folder_path) == ""
-            ):
+            if folder_path == folders[0]:
                 folder_tales["folders"].append(
                     {
                         "folder_name": os.path.basename(os.path.abspath(root_path)),
@@ -116,7 +113,7 @@ def process_repository(
             else:
                 folder_tales["folders"].append(
                     {
-                        "folder_name": os.path.basename(folder_path),
+                        "folder_name": folder_full_name,
                         "folder_summary": folder_tale,
                     }
                 )
@@ -227,7 +224,7 @@ def process_folder(
         """
         )
         logger.debug(f"FILE_TALES: {tales}")
-        return "", ""
+        return "-", "-"
 
     if tales:
         files_summaries = split_text(str(tales), chunk_size=10000)
@@ -263,7 +260,7 @@ def process_file(
 
     if debug:
         logger.debug(f"FILE INFO:\nfile_path: {file_path}\nsave_path: {save_path}")
-        return {"file_docstring": "Testing file docstring"}
+        return {"file_docstring": "-"}
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)

--- a/cli.py
+++ b/cli.py
@@ -87,7 +87,7 @@ def process_repository(
                     }
                 )
             else:
-                folders_readmes.append(folder_readme)
+                folders_readmes.append("\n" + folder_readme)
                 folder_tales["folders"].append(
                     {
                         "folder_name": os.path.basename(folder_path),
@@ -104,7 +104,7 @@ def process_repository(
 
         # inject folders information
         if folders_readmes:
-            folders_information = "\n\n## Folders\n\n" + "".join(folders_readmes)
+            folders_information = "\n\n## Folders\n" + "".join(folders_readmes)
             root_readme = root_readme + folders_information
 
         # inject project tree

--- a/cli.py
+++ b/cli.py
@@ -227,12 +227,15 @@ def process_folder(
 
     if tales:
         files_summaries = split_text(str(tales), chunk_size=10000)
-        folder_info = redact_tale_information(
+        # split into two calls to avoid issues with json decoding markdow text.
+        folder_readme = redact_tale_information(
             "folder-level", files_summaries, model_name="gpt-3.5-turbo-16k"
-        )
+        )["text"]
+        folder_readme = folder_readme.replace("----------", "")
 
-        folder_readme = folder_info["folder_readme"].replace("----------", "")
-        folder_tale = folder_info["folder_overview"]
+        folder_overview = redact_tale_information(
+            "folder-description", folder_readme, model_name="text-davinci-003"
+        )["text"]
 
         logger.info("save folder json..")
         with open(os.path.join(save_path, "folder_level.json"), "w") as json_file:
@@ -242,7 +245,7 @@ def process_folder(
         with open(os.path.join(save_path, "README.md"), "w", encoding="utf-8") as file:
             file.write(folder_readme)
 
-        return folder_readme, folder_tale
+        return folder_readme, folder_overview
     return None
 
 

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -40,11 +40,11 @@ Input: <<< {code} >>>
 """
 
 UNKNOWN_FILE_LEVEL_TEMPLATE = """
-Using the following code enclosed within the <<< >>> delimeters write a top-file level \
-docstring for a concise summary that effectively captures the overall purpose and \
-functionality of the code.
+Using the following file data enclosed within the <<< >>> delimeters write a \
+top-file level concise summary that effectively captures the overall purpose and \
+functionality of the file.
 
-code: <<< {information} >>>
+file data: <<< {information} >>>
 
 Ensure your final summary is no longer than three sentences.
 """
@@ -71,8 +71,7 @@ Structure:
 ----------
 #### <<<folder_name>>>
 
-<<<folder_overview>>> (Paragraph that concisely communicates the \
-folder's purpose.
+<<<folder_overview>>>
 
 - **<<<file_name>>>**: <<<file_description>>> (Your task it to
 write a short description of what the file does.)

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -64,23 +64,23 @@ FOLDER_LEVEL_TEMPLATE = """
 Generate a markdown text using the enclosed \
 information within the <<< >>> delimiters as your context. \
 Your output must strictly adhere to the provided structure below \
-without adding any other section more than the folder name on it.
+without adding any other section not mentioned on it.
 
-This is the structure your markdown text must have:
-Structure:
+This is the structure your output must have:
 ----------
 #### <<<folder_name>>>
+<<<folder_overview>>> (Provide a concise one-line sentence that describes the \
+primary purpose of the folder, utilizing all the contextual details available.)
 
-<<<folder_overview>>>
+**Files list:**
 
-- **<<<file_name>>>**: <<<file_description>>> (Your task it to
-write a short description of what the file does.)
+- **<<<file_name>>>**: <<<file_description>>> (short description of \
+what the file does.)
 ----------
 
 Folder information: <<< {information} >>>
 
-Ensure proper formatting and adhere to Markdown syntax guidelines, \
-and always use escaped newlines.
+Ensure proper formatting and adhere to Markdown syntax guidelines.
 Do not add sections that are not listed in the provided structure.
 """
 
@@ -106,7 +106,7 @@ available.)
 (In this section, your task is to create a single, well-structured \
 paragraph that concisely communicates the reasons behind the \
 repository's creation, its objectives, and the mechanics underlying \
-its functionality.)
+its functionality. Maximum three lines.)
 ----------
 
 Repository information: <<< {information} >>>

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -74,7 +74,7 @@ Structure:
 <<<folder_overview>>> (Paragraph that concisely communicates the \
 folder's purpose.
 
-- *<<<file_name>>>*: <<<file_description>>> (Your task it to
+- **<<<file_name>>>**: <<<file_description>>> (Your task it to
 write a short description of what the file does.)
 ----------
 

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -82,6 +82,7 @@ Folder information: <<< {information} >>>
 
 Ensure proper formatting and adhere to Markdown syntax guidelines.
 Do not add sections that are not listed in the provided structure.
+Do not backticks around the list titles and headers.
 """
 
 
@@ -104,9 +105,9 @@ available.)
 
 ## Overview
 (In this section, your task is to create a single, well-structured \
-paragraph that concisely communicates the reasons behind the \
+five-lines paragraph that concisely communicates the reasons behind the \
 repository's creation, its objectives, and the mechanics underlying \
-its functionality. Maximum three lines.)
+its functionality.)
 ----------
 
 Repository information: <<< {information} >>>

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -82,11 +82,6 @@ Folder information: <<< {information} >>>
 Ensure proper formatting and adhere to Markdown syntax guidelines, \
 and always use escaped newlines.
 Do not add sections that are not listed in the provided structure.
-
-Output your answer as a JSON with the keys: folder_overview and folder_readme.
-
-folder_readme is the markdown text, and folder_overview is a brief description \
-of the folder context.
 """
 
 
@@ -118,4 +113,11 @@ Repository information: <<< {information} >>>
 
 Ensure proper formatting and adhere to Markdown syntax guidelines.
 Do not add sections that are not listed in the provided structure.
+"""
+
+FOLDER_SHORT_DESCRIPTION_TEMPLATE = """
+Generate a one-line description of the folder's purpose based on \
+its following readme enclosed within the <<< >>> delimiters
+
+README: <<< {information} >>>
 """

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -105,7 +105,7 @@ def redact_tale_information(
     if not content_type == "unknow-top-level":
         information = str(docs[0].page_content)
     else:
-        information = docs
+        information = str(docs)
 
     text_answer = teller_of_tales({"information": information})
 
@@ -122,6 +122,7 @@ def redact_tale_information(
 def convert_to_json(text_answer):
     try:
         result_json = json.loads(text_answer["text"])
+        return result_json
     except JSONDecodeError:
         try:
             text = text_answer["text"].replace("\\n", "\n")
@@ -133,6 +134,7 @@ def convert_to_json(text_answer):
 
             json_text = _add_escape_characters(json_text)
             result_json = json.loads(json_text)
+            return result_json
 
         except Exception as e:
             print(
@@ -140,7 +142,6 @@ def convert_to_json(text_answer):
                 Error: {e} \n Result: {text_answer['text']}"
             )
             return None
-    return result_json
 
 
 def get_unit_tale(short_doc, code_elements, model_name="gpt-4", verbose=False):

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -15,6 +15,7 @@ from devtale.templates import (
     CODE_LEVEL_TEMPLATE,
     FILE_LEVEL_TEMPLATE,
     FOLDER_LEVEL_TEMPLATE,
+    FOLDER_SHORT_DESCRIPTION_TEMPLATE,
     ROOT_LEVEL_TEMPLATE,
     UNKNOWN_FILE_LEVEL_TEMPLATE,
 )
@@ -24,6 +25,7 @@ TYPE_INFORMATION = {
     "folder-level": FOLDER_LEVEL_TEMPLATE,
     "root-level": ROOT_LEVEL_TEMPLATE,
     "unknow-top-level": UNKNOWN_FILE_LEVEL_TEMPLATE,
+    "folder-description": FOLDER_SHORT_DESCRIPTION_TEMPLATE,
 }
 
 
@@ -102,19 +104,12 @@ def redact_tale_information(
     teller_of_tales = LLMChain(
         llm=OpenAI(model_name=model_name), prompt=prompt, verbose=verbose
     )
-    if not content_type == "unknow-top-level":
+    if content_type not in ["unknow-top-level", "folder-description"]:
         information = str(docs[0].page_content)
     else:
         information = str(docs)
 
     text_answer = teller_of_tales({"information": information})
-
-    if content_type == "folder-level":
-        json_answer = convert_to_json(text_answer)
-        if not json_answer:
-            print("Returning empty JSON due to a failure")
-            json_answer = {"folder_overview": "", "folder_readme": ""}
-        return json_answer
 
     return text_answer
 


### PR DESCRIPTION
This PR fixes regression introduced by #43 and #41 

It also: 
- adds a debugging flag to avoid calling GPT when debugging pipeline paths workflow
- adds existing README information into the generated one. It renames the old one as `old_readme.md`
- enhances the unknown files (files without extension) overview