### PR TITLE
Add no-code file processing

### DIFF
--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -1,7 +1,8 @@
 from langchain.text_splitter import Language
 
 # we are only documenting the file that ends with the following extensions:
-ALLOWED_EXTENSIONS = [".js", ".go", ".php", ".py", ""]
+ALLOWED_EXTENSIONS = [".js", ".go", ".php", ".py"]
+ALLOWED_NO_CODE_EXTENSIONS = ["", ".sh", ".xml", ".yaml", ".yml"]
 
 # split code files according the programming language
 LANGUAGES = {

--- a/devtale/templates.py
+++ b/devtale/templates.py
@@ -39,7 +39,7 @@ use escaped newlines.
 Input: <<< {code} >>>
 """
 
-UNKNOWN_FILE_LEVEL_TEMPLATE = """
+NO_CODE_FILE_TEMPLATE = """
 Using the following file data enclosed within the <<< >>> delimeters write a \
 top-file level concise summary that effectively captures the overall purpose and \
 functionality of the file.

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -17,15 +17,15 @@ from devtale.templates import (
     FILE_LEVEL_TEMPLATE,
     FOLDER_LEVEL_TEMPLATE,
     FOLDER_SHORT_DESCRIPTION_TEMPLATE,
+    NO_CODE_FILE_TEMPLATE,
     ROOT_LEVEL_TEMPLATE,
-    UNKNOWN_FILE_LEVEL_TEMPLATE,
 )
 
 TYPE_INFORMATION = {
     "top-level": FILE_LEVEL_TEMPLATE,
     "folder-level": FOLDER_LEVEL_TEMPLATE,
     "root-level": ROOT_LEVEL_TEMPLATE,
-    "unknow-top-level": UNKNOWN_FILE_LEVEL_TEMPLATE,
+    "no-code-file": NO_CODE_FILE_TEMPLATE,
     "folder-description": FOLDER_SHORT_DESCRIPTION_TEMPLATE,
 }
 
@@ -105,7 +105,7 @@ def redact_tale_information(
     teller_of_tales = LLMChain(
         llm=OpenAI(model_name=model_name), prompt=prompt, verbose=verbose
     )
-    if content_type not in ["unknow-top-level", "folder-description"]:
+    if content_type not in ["no-code-file", "folder-description"]:
         information = str(docs[0].page_content)
     else:
         information = str(docs)


### PR DESCRIPTION
This PR allows processing .sh, .xml, .yaml, .yml, and files without extension considering them as `no-code` files. It also handles possible `max_token` issue for large files 