### PR TITLE
Estimate approximate cost and total cost

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,7 @@ from devtale.utils import (
     redact_tale_information,
     split_code,
     split_text,
+    update_budget,
 )
 
 DEFAULT_OUTPUT_PATH = "devtale_demo/"
@@ -44,7 +45,9 @@ def process_repository(
     model_name: str = DEFAULT_MODEL_NAME,
     fuse: bool = False,
     debug: bool = False,
+    is_estimation: bool = True,
 ) -> None:
+    budget = 0
     folder_tales = {
         "repository_name": os.path.basename(os.path.abspath(root_path)),
         "folders": [],
@@ -90,7 +93,7 @@ def process_repository(
 
             folder_full_name = os.path.relpath(folder_path, root_path)
 
-            folder_readme, folder_tale = process_folder(
+            folder_readme, folder_tale, folder_budget = process_folder(
                 folder_path=folder_path,
                 output_path=os.path.join(output_path, folder_full_name)
                 if folder_full_name != "."
@@ -99,7 +102,9 @@ def process_repository(
                 fuse=fuse,
                 debug=debug,
                 folder_full_name=folder_full_name,
+                is_estimation=is_estimation,
             )
+            budget += folder_budget
 
         except Exception as e:
             folder_name = os.path.basename(folder_path)
@@ -133,9 +138,13 @@ def process_repository(
 
     if folder_tales:
         folder_summaries = split_text(str(folder_tales), chunk_size=15000)
-        root_readme = redact_tale_information(
-            "root-level", folder_summaries, model_name="gpt-3.5-turbo-16k"
-        )["text"]
+        root_readme, tokens = redact_tale_information(
+            "root-level",
+            folder_summaries,
+            model_name="gpt-3.5-turbo-16k",
+            is_estimation=is_estimation,
+        )
+        budget += update_budget(tokens, "gpt-3.5-turbo-16k")
         root_readme = root_readme.replace("----------", "")
 
         # inject folders information
@@ -168,6 +177,8 @@ def process_repository(
         ) as file:
             file.write(root_readme)
 
+    return budget
+
 
 def process_folder(
     folder_path: str,
@@ -176,7 +187,9 @@ def process_folder(
     fuse: bool = False,
     debug: bool = False,
     folder_full_name: str = None,
+    is_estimation: bool = False,
 ) -> None:
+    budget = 0
     save_path = os.path.join(output_path, os.path.basename(folder_path))
     tales = []
 
@@ -189,7 +202,10 @@ def process_folder(
         ):
             logger.info(f"processing {file_path}")
             try:
-                file_tale = process_file(file_path, save_path, model_name, fuse, debug)
+                file_tale, file_budget = process_file(
+                    file_path, save_path, model_name, fuse, debug, is_estimation
+                )
+                budget += file_budget
             except Exception as e:
                 logger.info(
                     f"Failed to create dev tale for {file_path} - Exception: {e}"
@@ -250,14 +266,22 @@ def process_folder(
     if tales:
         files_summaries = split_text(str(tales), chunk_size=10000)
         # split into two calls to avoid issues with json decoding markdow text.
-        folder_readme = redact_tale_information(
-            "folder-level", files_summaries, model_name="gpt-3.5-turbo-16k"
-        )["text"]
+        folder_readme, fl_tokens = redact_tale_information(
+            "folder-level",
+            files_summaries,
+            model_name="gpt-3.5-turbo-16k",
+            is_estimation=is_estimation,
+        )
         folder_readme = folder_readme.replace("----------", "")
 
-        folder_overview = redact_tale_information(
-            "folder-description", folder_readme, model_name="gpt-3.5-turbo-16k"
-        )["text"]
+        folder_overview, fd_tokens = redact_tale_information(
+            "folder-description",
+            folder_readme,
+            model_name="gpt-3.5-turbo-16k",
+            is_estimation=is_estimation,
+        )
+
+        budget += update_budget(fl_tokens + fd_tokens, "gpt-3.5-turbo-16k")
 
         logger.info("save folder json..")
         with open(os.path.join(save_path, "folder_level.json"), "w") as json_file:
@@ -267,8 +291,8 @@ def process_folder(
         with open(os.path.join(save_path, "README.md"), "w", encoding="utf-8") as file:
             file.write(folder_readme)
 
-        return folder_readme, folder_overview
-    return None
+        return folder_readme, folder_overview, budget
+    return None, None, budget
 
 
 def process_file(
@@ -277,14 +301,16 @@ def process_file(
     model_name: str = DEFAULT_MODEL_NAME,
     fuse: bool = False,
     debug: bool = False,
+    is_estimation: bool = False,
 ) -> None:
+    budget = 0
     file_name = os.path.basename(file_path)
     file_ext = os.path.splitext(file_name)[-1]
     save_path = os.path.join(output_path, f"{file_name}.json")
 
     if debug:
         logger.debug(f"FILE INFO:\nfile_path: {file_path}\nsave_path: {save_path}")
-        return {"file_docstring": "-"}
+        return {"file_docstring": "-"}, budget
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -294,7 +320,7 @@ def process_file(
         code = file.read()
 
     if not code:
-        return {"file_docstring": ""}
+        return {"file_docstring": ""}, budget
 
     if os.path.exists(save_path):
         logger.info(f"Skipping {file_name} as its tale file already exists.")
@@ -302,7 +328,7 @@ def process_file(
             found_tale = json.load(file)
         if fuse:
             fuse_documentation(code, found_tale, output_path, file_name, file_ext)
-        return found_tale
+        return found_tale, budget
 
     if not file_ext or file_ext in ALLOWED_NO_CODE_EXTENSIONS:
         # a small single chunk is enough
@@ -311,10 +337,15 @@ def process_file(
             "file_name": file_name,
             "file_content": no_code_file,
         }
-        file_docstring = redact_tale_information("no-code-file", no_code_file_data)[
-            "text"
-        ]
-        return {"file_docstring": file_docstring}
+        file_docstring, tokens = redact_tale_information(
+            content_type="no-code-file",
+            docs=no_code_file_data,
+            model_name="text-davinci-003",
+            is_estimation=is_estimation,
+        )
+        budget += update_budget(tokens, "text-davinci-003")
+
+        return {"file_docstring": file_docstring}, budget
 
     logger.info("split dev draft ideas")
     big_docs = split_code(code, language=LANGUAGES[file_ext], chunk_size=10000)
@@ -323,7 +354,10 @@ def process_file(
     logger.info("extract code elements")
     code_elements = []
     for idx, doc in enumerate(big_docs):
-        elements_set = extract_code_elements(doc)
+        elements_set, tokens = extract_code_elements(
+            big_doc=doc, model_name=model_name, is_estimation=is_estimation
+        )
+        budget += update_budget(tokens, model_name)
         if elements_set:
             code_elements.append(elements_set)
 
@@ -343,9 +377,15 @@ def process_file(
     logger.info("create tale sections")
     tales_list = []
     # process only if we have elements to document
-    if code_elements_copy:
+    if code_elements_copy or is_estimation:
         for idx, doc in enumerate(short_docs):
-            tale = get_unit_tale(doc, code_elements_copy, model_name=model_name)
+            tale, tokens = get_unit_tale(
+                short_doc=doc,
+                code_elements=code_elements_copy,
+                model_name=model_name,
+                is_estimation=is_estimation,
+            )
+            budget += update_budget(tokens, model_name)
             tales_list.append(tale)
             logger.info(f"tale section {str(idx+1)}/{len(short_docs)} done.")
 
@@ -361,7 +401,13 @@ def process_file(
     logger.info("add dev tale summary")
     summaries = split_text(str(code_elements_dict["summary"]), chunk_size=9000)
 
-    file_docstring = redact_tale_information("top-level", summaries)["text"]
+    file_docstring, tokens = redact_tale_information(
+        content_type="top-level",
+        docs=summaries,
+        model_name="text-davinci-003",
+        is_estimation=is_estimation,
+    )
+    budget += update_budget(tokens, "text-davinci-003")
 
     if fuse:
         # add docstring label only to insert it along the docstring into the code
@@ -374,7 +420,7 @@ def process_file(
     with open(save_path, "w") as json_file:
         json.dump(tale, json_file, indent=2)
 
-    return tale
+    return tale, budget
 
 
 def fuse_documentation(code, tale, output_path, file_name, file_ext):
@@ -461,33 +507,39 @@ def main(
     if os.path.isdir(path):
         if recursive:
             logger.info("Processing repository")
-            process_repository(
+            price = process_repository(
                 root_path=path,
                 output_path=output_path,
                 model_name=model_name,
                 fuse=fuse,
                 debug=debug,
+                is_estimation=True,
             )
         else:
             logger.info("Processing folder")
-            process_folder(
+            _, price = process_folder(
                 folder_path=path,
                 output_path=output_path,
                 model_name=model_name,
                 fuse=fuse,
                 debug=debug,
+                is_estimation=False,
             )
     elif os.path.isfile(path):
         logger.info("Processing file")
-        process_file(
+        _, price = process_file(
             file_path=path,
             output_path=output_path,
             model_name=model_name,
             fuse=fuse,
             debug=debug,
+            is_estimation=False,
         )
+
     else:
         raise f"Invalid input path {path}. Path must be a directory or code file."
+
+    logger.info(f"Rough cost = {price}")
 
 
 if __name__ == "__main__":

--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -13,3 +13,5 @@ LANGUAGES = {
 }
 
 DOCSTRING_LABEL = "@DEVTALE-GENERATED:"
+
+GPT_PRICE = {"gpt-4": 0.03, "gpt-3.5-turbo-16k": 0.03, "text-davinci-003": 0.0015}

--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -14,4 +14,5 @@ LANGUAGES = {
 
 DOCSTRING_LABEL = "@DEVTALE-GENERATED:"
 
+# Extracted from https://openai.com/pricing on September 26th, 2023.
 GPT_PRICE = {"gpt-4": 0.03, "gpt-3.5-turbo-16k": 0.03, "text-davinci-003": 0.0015}

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -33,7 +33,7 @@ TYPE_INFORMATION = {
 
 
 def calculate_cost(input: str, model: str):
-    if model == "davinci":
+    if model == "text-davinci-003":
         encoding = "p50k_base"
     else:
         encoding = "cl100k_base"
@@ -59,7 +59,7 @@ def split_code(code, language, chunk_size=1000, chunk_overlap=0):
 
 
 def extract_code_elements(
-    big_doc, verbose=False, model_name="gpt-4", is_estimation=False
+    big_doc, verbose=False, model_name="gpt-4", cost_estimation=False
 ):
     prompt = PromptTemplate(
         template=CODE_EXTRACTOR_TEMPLATE,
@@ -69,7 +69,7 @@ def extract_code_elements(
         llm=ChatOpenAI(model_name=model_name), prompt=prompt, verbose=verbose
     )
 
-    if is_estimation:
+    if cost_estimation:
         estimated_cost = calculate_cost(
             prompt.format(code=big_doc.page_content), model_name
         )
@@ -124,7 +124,7 @@ def redact_tale_information(
     docs,
     verbose=False,
     model_name="text-davinci-003",
-    is_estimation=False,
+    cost_estimation=False,
 ):
     prompt = PromptTemplate(
         template=TYPE_INFORMATION[content_type], input_variables=["information"]
@@ -137,7 +137,7 @@ def redact_tale_information(
     else:
         information = str(docs)
 
-    if is_estimation:
+    if cost_estimation:
         estimated_cost = calculate_cost(
             prompt.format(information=information), model_name
         )
@@ -176,7 +176,7 @@ def convert_to_json(text_answer):
 
 
 def get_unit_tale(
-    short_doc, code_elements, model_name="gpt-4", verbose=False, is_estimation=False
+    short_doc, code_elements, model_name="gpt-4", verbose=False, cost_estimation=False
 ):
     parser = PydanticOutputParser(pydantic_object=FileDocumentation)
     prompt = PromptTemplate(
@@ -188,7 +188,7 @@ def get_unit_tale(
         llm=ChatOpenAI(model_name=model_name), prompt=prompt, verbose=verbose
     )
 
-    if is_estimation:
+    if cost_estimation:
         estimated_cost = calculate_cost(
             prompt.format(
                 code=short_doc.page_content, code_elements=str(code_elements)


### PR DESCRIPTION
This PR introduces the `--estimation` flag, which allows for the approximate cost calculation of documenting a repository, folder, or file without making any GPT calls. However, it is not entirely precise, as it requires aggregating the output tokens (GPT answer) and the JSON data generated by the `extract_code_elements` function, which is used as part of the input for the process. Nonetheless, this cost estimation provides a rough idea of what will be the minimum cost.

In addition, this PR enhances the code to always display the total cost after documenting the code, which yield a more accurate result since GPT calls are made, and the cost calculation takes into account both the output tokens and the generated JSON data for functions and classes.

For illustration, using a testing repository, the approximate cost was $2.4473 (no GPT calls done), and the total cost came to $2.9576 (GPT calls done).