### PR TITLE
Allow processing ts and tsx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devtale
 
-Generate full documentation for your code repos. `devtale` supports Python, Go, React Javascript, and PHP files.
+Generate full documentation for your code repos. `devtale` supports Python, Go, PHP, and React files.
 
 https://github.com/mystral-ai/devtale/assets/11546115/e3cb1354-d9ef-406f-90d7-e92576587549
 

--- a/cli.py
+++ b/cli.py
@@ -438,7 +438,7 @@ def fuse_documentation(code, tale, output_path, file_name, file_ext):
         aggregator = PHPAggregator()
     elif file_ext == ".go":
         aggregator = GoAggregator()
-    elif file_ext == ".js":
+    elif file_ext == ".js" or file_ext == ".ts" or file_ext == ".tsx":
         aggregator = JavascriptAggregator()
 
     fused_tale = aggregator.document(code=code, documentation=tale)

--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -1,7 +1,7 @@
 from langchain.text_splitter import Language
 
 # we are only documenting the file that ends with the following extensions:
-ALLOWED_EXTENSIONS = [".js", ".go", ".php", ".py"]
+ALLOWED_EXTENSIONS = [".js", ".go", ".php", ".py", ".ts", ".tsx"]
 ALLOWED_NO_CODE_EXTENSIONS = ["", ".sh", ".xml", ".yaml", ".yml"]
 
 # split code files according the programming language
@@ -10,6 +10,8 @@ LANGUAGES = {
     ".py": Language.PYTHON,
     ".go": Language.GO,
     ".js": Language.JS,
+    ".ts": Language.JS,
+    ".tsx": Language.JS,
 }
 
 DOCSTRING_LABEL = "@DEVTALE-GENERATED:"


### PR DESCRIPTION
This PR used langchain's JS splitter to handle ts and tsx files. The Javascript aggregators is able to add docstrings into the ts and tsx files as well (although it may not be very robust yet) 