### PR TITLE
dev:  update the deprecated davinci OpenAI's model to the GPT-3.5 model version.

### DIFF
--- a/devtale/cli.py
+++ b/devtale/cli.py
@@ -390,7 +390,7 @@ def process_file(
         file_docstring, call_cost = redact_tale_information(
             content_type="no-code-file",
             docs=no_code_file_data,
-            model_name="text-davinci-003",
+            model_name="gpt-3.5-turbo",
             cost_estimation=cost_estimation,
         )
         cost += call_cost
@@ -467,7 +467,7 @@ def process_file(
     file_docstring, call_cost = redact_tale_information(
         content_type="top-level",
         docs=summaries,
-        model_name="text-davinci-003",
+        model_name="gpt-3.5-turbo",
         cost_estimation=cost_estimation,
     )
     cost += call_cost

--- a/devtale/constants.py
+++ b/devtale/constants.py
@@ -16,5 +16,5 @@ LANGUAGES = {
 
 DOCSTRING_LABEL = "@DEVTALE-GENERATED:"
 
-# Extracted from https://openai.com/pricing on September 26th, 2023.
-GPT_PRICE = {"gpt-4": 0.03, "gpt-3.5-turbo-16k": 0.03, "text-davinci-003": 0.0015}
+# Extracted from https://openai.com/pricing on January 15th, 2024.
+GPT_PRICE = {"gpt-4": 0.03, "gpt-3.5-turbo-16k": 0.0010, "gpt-3.5-turbo": 0.0015}

--- a/devtale/utils.py
+++ b/devtale/utils.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError
 from pathlib import Path
 
 import tiktoken
-from langchain import LLMChain, OpenAI, PromptTemplate
+from langchain import LLMChain, PromptTemplate
 from langchain.callbacks import get_openai_callback
 from langchain.chat_models import ChatOpenAI
 from langchain.output_parsers import PydanticOutputParser
@@ -117,14 +117,14 @@ def redact_tale_information(
     content_type,
     docs,
     verbose=False,
-    model_name="text-davinci-003",
+    model_name="gpt-3.5-turbo",
     cost_estimation=False,
 ):
     prompt = PromptTemplate(
         template=TYPE_INFORMATION[content_type], input_variables=["information"]
     )
     teller_of_tales = LLMChain(
-        llm=OpenAI(model_name=model_name), prompt=prompt, verbose=verbose
+        llm=ChatOpenAI(model_name=model_name), prompt=prompt, verbose=verbose
     )
     if content_type not in ["no-code-file", "folder-description"]:
         information = str(docs[0].page_content)
@@ -250,12 +250,7 @@ def fuse_documentation(code, tale, file_ext, save_path):
 
 
 def _calculate_cost(input: str, model: str):
-    if model == "text-davinci-003":
-        encoding = "p50k_base"
-    else:
-        encoding = "cl100k_base"
-
-    tokens = tiktoken.get_encoding(encoding).encode(input)
+    tokens = tiktoken.get_encoding("cl100k_base").encode(input)
     return (len(tokens) / 1000) * GPT_PRICE[model]
 
 


### PR DESCRIPTION
The `text-davinci-003` model from OpenAI was deprecated, leading to errors. This PR updates the model to the `GPT-3.5-turbo` version and revises the pre-estimation based on the new pricing.